### PR TITLE
Fixing some error-handling logic in the sendMsg code.

### DIFF
--- a/hriemann.cabal
+++ b/hriemann.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: cda6f6548a8d70c5dea6941429fe0fe72a2613682c484fbdbd4246661ac0d25a
+-- hash: 5ca5823f2b11010648ab39f12ed719581c100a8d0da5e71d4248189a9afd02bd
 
 name:           hriemann
 version:        0.3.3.0
@@ -59,6 +59,7 @@ library
     , protocol-buffers
     , protocol-buffers-descriptor
     , scientific
+    , stm
     , text
     , time
     , unagi-chan

--- a/package.yaml
+++ b/package.yaml
@@ -42,6 +42,7 @@ library:
   - binary
   - time
   - mtl
+  - stm
   - hostname
   - unagi-chan
   - kazura-queue


### PR DESCRIPTION
This could deadlock, because MVars require every write to be matched
with a read. Read (or write) twice in a row and the code freezes.

I've replaced MVar with a TVar, which is more flexible, and in doing so
I've been able to tidy up the code a little too.